### PR TITLE
Create SkipCutsceneON.js

### DIFF
--- a/scripts/SkipCutscenesON.js
+++ b/scripts/SkipCutscenesON.js
@@ -1,0 +1,4 @@
+// Automatically skip any cutscene. (Includes even mainstream quest cutscenes. Use with caution.) (Created by Step29, converted from mod_sharker by C0ZIEST, fixed by Poshwosh)
+
+var pattern = scan('?? ?? ?? 75 05 39 ?? ?? ?? ?? ?? ?? E0');
+patch(pattern.add(3), 0xEB);


### PR DESCRIPTION
Another restored script part of #46. Originally created by Step29.

This script causes any cutscene to break, automatically skipping it as a result. This might not be fitting for some people, so this should go to disabled.txt.

When I used cutscene skip before, it was mostly for grinding purposes (farming for a pass, doing tournament), and afterwards I would turn cutscenes back on. With that in mind, I created an OFF file to revert the changes without having to restart the client.

However, this is very savvy. I propose that Kanan should have a switch function, a way to patch a variable to a different value through the CMD console.
For example, this is I would have wanted the file to work:

```
var pattern = scan('?? ?? ?? 75 05 39 ?? ?? ?? ?? ?? ?? E0');
patch(pattern.add(3), 0x75);
patch.on{pattern.add(3), 0xEB);
patch.off{pattern.add(3), 0x75);
```

By default, the script would be off. In the console, you would type "SkipCutscene.js on" to execute the script again on the switch titled "on". If I ever find a way to change default ranged attack, could make multiple switches for each one of them (ex DefaultRangedAttack.js Magnum)

I understand this might take a while, so I decide to go with this ON and OFF thing for the time being. If you don't like it, reject the OFF file.
