### PR TITLE
Patch the check, not the title ID.

### DIFF
--- a/scripts/ClientSideDevCat.js
+++ b/scripts/ClientSideDevCat.js
@@ -1,5 +1,9 @@
-// Gives You DevCat Title To See Extra Information In Various Places (Rydian)
+// Enable Devcat Effects (Rydian)
 
-var pattern = scan('08 00 66 8B 41 10 C3');
+//Title IDs are in data/db/title.xml.
+//Find yours, find the code that reads it.
+//Right after it returns, there's a check to modify.
 
-patch(pattern.add(3), [0xB8, 0x61, 0xEA]);
+var pattern = scan('74 21 8B 16 8B 82 94 00 00 00 8B CE');
+
+patch(pattern.add(0), 0xEB);


### PR DESCRIPTION
Enables the effects without the fake titles popping up everywhere.
