### PR TITLE
Add DisableScreenFlash.js

### DIFF
--- a/scripts/DisableScreenFlash.js
+++ b/scripts/DisableScreenFlash.js
@@ -1,0 +1,4 @@
+// Disables screen flashes from occuring. This includes: Shuriken Charge, Focused Fist. (Created by Step29, fixed by Poshwosh)
+
+var pattern = scan('55 1C 53 ?? ?? ?? ?? ?? ?? ?? ?? 56');
+patch(pattern.add(0), [0x6A, 0x00, 0x90]);


### PR DESCRIPTION
This modification used to be called NoFade and was created by Step29. Part of request #46. 

This script disables flashes. Not flashy dyes, but that white flash when you fully charge shuriken charge & focused fist. If anybody else knows what it affects please add to the description. 

(It doesn't hide curtains, sorry C0ZIEST)

I think it should be in disabled.txt, it could confuse people who aren't aware its installed.
