### PR TITLE
DisableScreenFlash.js Meteor strike "FPS bomb" fix

### DIFF
--- a/disabled.txt
+++ b/disabled.txt
@@ -1,4 +1,3 @@
-DisableScreenFlash.js
 GlobalHeightOverride.js
 HideObjects.js
 PatternScanSnapshot.js

--- a/scripts/DisableScreenFlash.js
+++ b/scripts/DisableScreenFlash.js
@@ -1,4 +1,4 @@
-// Disables screen flashes from occuring. This includes: Shuriken Charge, Focused Fist. (Created by Step29, fixed by Poshwosh)
+// Disables white screen flashes from occuring while loading or executing the follow skills: Shuriken Charge, Focused Fist, Meteor Strike, Thunder, and Critical Hit. (Created by Step29, fixed by Poshwosh)
 
 var pattern = scan('55 1C 53 ?? ?? ?? ?? ?? ?? ?? ?? 56');
 patch(pattern.add(2), [0x50]);

--- a/scripts/DisableScreenFlash.js
+++ b/scripts/DisableScreenFlash.js
@@ -1,4 +1,4 @@
 // Disables screen flashes from occuring. This includes: Shuriken Charge, Focused Fist. (Created by Step29, fixed by Poshwosh)
 
 var pattern = scan('55 1C 53 ?? ?? ?? ?? ?? ?? ?? ?? 56');
-patch(pattern.add(0), [0x6A, 0x00, 0x90]);
+patch(pattern.add(2), [0x50]);

--- a/scripts/DisableScreenFlash.js
+++ b/scripts/DisableScreenFlash.js
@@ -1,4 +1,4 @@
-// Disables white screen flashes from occuring while loading or executing the follow skills: Shuriken Charge, Focused Fist, Meteor Strike, Thunder, and Critical Hit. (Created by Step29, fixed by Poshwosh)
+// Disables white screen flashes from occuring while loading or executing the following skills: Shuriken Charge, Focused Fist, Meteor Strike, Thunder, and Critical Hit. (Created by Step29, fixed by Poshwosh)
 
 var pattern = scan('55 1C 53 ?? ?? ?? ?? ?? ?? ?? ?? 56');
 patch(pattern.add(2), [0x50]);


### PR DESCRIPTION
This fixes the major FPS drop while executing the skill Meteor Strike, as explained in issue #77.

I have tested it with meteor strike, and multiple skills, it seems to be functioning as intended now.

I solved nuclear war problems with bytes.
