### PR TITLE
Rename to PersistentHideInterface.js & fix

### DIFF
--- a/coalesce.txt
+++ b/coalesce.txt
@@ -12,7 +12,6 @@ ElfLagFix.js
 EnableFSAA.js
 EnableInterfaceWhileDead.js
 FarAltText.js
-PersistentHideInterface.js
 FOVChange.js
 FreeIndoorCamera.js
 FreezeTimeOfDay.js
@@ -40,6 +39,7 @@ NoPlayerZoomTransparency.js
 NoSkillRankUpWindow.js
 NPCFastText.js
 OneClickRevive.js
+PersistentHideInterface.js
 RangedAttackSwap.js
 RemoveDungeonFog.js
 RemoveScreenShake.js

--- a/coalesce.txt
+++ b/coalesce.txt
@@ -3,8 +3,8 @@ BitmapFont.js
 ChatAllowSameMsg.js
 ChatNoRateLimit.js
 ChatToMiniGamers.js
-ClientSideDevCat.js
 ColorAltText.js
+devCATEffects.js
 DisableScreenFlash.js
 DontTargetNPCs.js
 DungeonMapResize.js

--- a/coalesce.txt
+++ b/coalesce.txt
@@ -12,7 +12,7 @@ ElfLagFix.js
 EnableFSAA.js
 EnableInterfaceWhileDead.js
 FarAltText.js
-FighterNoForce.js
+PersistentHideInterface.js
 FOVChange.js
 FreeIndoorCamera.js
 FreezeTimeOfDay.js

--- a/scripts/FighterNoForce.js
+++ b/scripts/FighterNoForce.js
@@ -1,5 +1,0 @@
-// No Persistent Fighter Chain Popup (Rydian)
-
-var pattern = scan('83 79 44 01 75 09 6A 00 6A 00 E8');
-
-patch(pattern.add(4), 0xEB);

--- a/scripts/PersistentHideInterface.js
+++ b/scripts/PersistentHideInterface.js
@@ -1,4 +1,5 @@
-// While in hide interface mode, using chain combo fighter skills will turn the interface back on. This disables this trigger, persisting the interface to stay hidden. (Created by Rydian)
+// Description: 
+// While in hide interface mode, using chain combo fighter skills will turn the interface back on. This disables this trigger, persisting the interface to stay hidden. (created by Rydian)
 
 var secondchain = scan('83 79 44 01 75 09 6A 00 6A 00 E8');
 patch(secondchain.add(4), 0xEB);

--- a/scripts/PersistentHideInterface.js
+++ b/scripts/PersistentHideInterface.js
@@ -1,0 +1,6 @@
+// While in hide interface mode, using chain combo fighter skills will turn the interface back on. This disables this trigger, persisting the interface to stay hidden. (Created by Rydian)
+
+var secondchain = scan('83 79 44 01 75 09 6A 00 6A 00 E8');
+patch(secondchain.add(4), 0xEB);
+var thirdchain = scan('83 79 44 01 75 09 6A 00 6A 00 E8');
+patch(thirdchain.add(4), 0xEB);


### PR DESCRIPTION
FighterNoForce isn't very direct, I believe PersistentHideInterface is more of that on the other hand.

The script did not seem to work originally.

Looking at it on debug mode, kanan detected there are two similar values. Applying a second patch to the second found value makes the script work as intended, no popup.

However disabling the first patch breaks it again. 

As a result, I came to the conclusion each of them is for the second and third chain combo respectively, and they both need to be patched together for this to work as intended.
